### PR TITLE
Fix unnecessary catkin_package dependencies

### DIFF
--- a/uuv_gazebo_plugins/uuv_gazebo_plugins/CMakeLists.txt
+++ b/uuv_gazebo_plugins/uuv_gazebo_plugins/CMakeLists.txt
@@ -53,7 +53,6 @@ catkin_package(
     thruster_plugin 
     fin_plugin
     dynamics
-  DEPENDS gazebo
 )
 
 include_directories(${PROJECT_SOURCE_DIR}/include

--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/CMakeLists.txt
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/CMakeLists.txt
@@ -195,7 +195,7 @@ list(APPEND UUV_SENSOR_ROS_PLUGINS_LIST uuv_gazebo_ros_rpt_plugin)
 ###############################################################################
 
 add_library(uuv_gazebo_ros_camera_plugin src/UnderwaterCameraROSPlugin.cc)
-target_link_libraries(uuv_gazebo_ros_camera_plugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+target_link_libraries(uuv_gazebo_ros_camera_plugin DepthCameraPlugin ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
 add_dependencies(uuv_gazebo_ros_camera_plugin ${catkin_EXPORTED_TARGETS})
 list(APPEND UUV_SENSOR_ROS_PLUGINS_LIST uuv_gazebo_ros_camera_plugin)
 

--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/CMakeLists.txt
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/CMakeLists.txt
@@ -64,7 +64,6 @@ catkin_package(
     ${OGRE_Paging_INCLUDE_DIRS}
     ${OpenCV_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}
-  DEPENDS Eigen3 gazebo
   CATKIN_DEPENDS
     uuv_gazebo_plugins
     sensor_msgs

--- a/uuv_sensor_plugins/uuv_sensor_ros_plugins/include/uuv_sensor_ros_plugins/UnderwaterCameraROSPlugin.hh
+++ b/uuv_sensor_plugins/uuv_sensor_ros_plugins/include/uuv_sensor_ros_plugins/UnderwaterCameraROSPlugin.hh
@@ -23,6 +23,7 @@
 #include <gazebo_plugins/gazebo_ros_camera_utils.h>
 #include <uuv_sensor_ros_plugins/Common.hh>
 #include <opencv2/opencv.hpp>
+#include <boost/random.hpp>
 
 namespace gazebo
 {
@@ -56,6 +57,10 @@ namespace gazebo
      const cv::Mat& _inputImage, const cv::Mat& _inputDepth,
      cv::Mat& _outputImage);
 
+    protected: virtual void SimulateUnderwaterBW(
+      const cv::Mat& _inputImage, const cv::Mat& _inputDepth,
+      cv::Mat& _outputImage);
+
     /// \brief Temporarily store pointer to previous depth image.
     protected: const float * lastDepth;
 
@@ -70,6 +75,12 @@ namespace gazebo
 
     /// \brief Background constants per channel (RGB)
     protected: unsigned char background[3];
+
+    /// \brief Mersenne Twister RNG for noise
+    protected: boost::mt19937 rng_;
+
+    /// \brief Standard deviation for Gaussian noise model
+    protected: double stdDev_;
   };
 }
 

--- a/uuv_world_plugins/uuv_world_plugins/CMakeLists.txt
+++ b/uuv_world_plugins/uuv_world_plugins/CMakeLists.txt
@@ -20,7 +20,6 @@ catkin_package(
                ${Boost_INCLUDE_DIRS}
 	LIBRARIES uuv_underwater_current_plugin
 	CATKIN_DEPENDS gazebo_msgs
-	DEPENDS gazebo
 )
 
 include_directories(include


### PR DESCRIPTION
These dependencies cause warnings, and are redundant as the relevant
include directories or libraries were already declared as dependencies
themselves.

Signed-off-by: Ag Despopoulos <agdespopoulos@gmail.com>